### PR TITLE
Deleted h2 dependency in the parent 

### DIFF
--- a/terasoluna-tourreservation-parent/pom.xml
+++ b/terasoluna-tourreservation-parent/pom.xml
@@ -363,12 +363,6 @@
 
             <!-- == Begin Database == -->
             <dependency>
-                <groupId>com.h2database</groupId>
-                <artifactId>h2</artifactId>
-                <version>${h2.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
                 <groupId>org.postgresql</groupId>
                 <artifactId>postgresql</artifactId>
                 <version>${postgresql.version}</version>


### PR DESCRIPTION
backport from jpa/master.
Please review terasolunaorg/terasoluna-tourreservation#185, and merge to master branch.
(cherry picked from commit f96bd63234ec33a4580ac734db61484e116c2cde)