### PR TITLE
remove un-need dependency JAXB which changed to automatically be depended with dozer-core 6.5.0 #673

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -182,16 +182,6 @@
         <artifactId>javax.annotation-api</artifactId>
         <version>${javax.annotation-api.version}</version>
       </dependency>
-      <dependency>
-        <groupId>com.sun.xml.bind</groupId>
-        <artifactId>jaxb-core</artifactId>
-        <version>${jaxb-core.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.sun.xml.bind</groupId>
-        <artifactId>jaxb-impl</artifactId>
-        <version>${jaxb-impl.version}</version>
-      </dependency>
       <!-- == End For JDK 11 == -->
 
     </dependencies>
@@ -207,8 +197,6 @@
     <postgresql.version>42.2.9</postgresql.version>
     <webdrivermanager.version>3.1.1</webdrivermanager.version>
     <javax.annotation-api.version>1.3.2</javax.annotation-api.version>
-    <jaxb-core.version>2.3.0.1</jaxb-core.version>
-    <jaxb-impl.version>2.3.2</jaxb-impl.version>
     <!-- == Project Properties == -->
     <encoding>UTF-8</encoding>
     <java-version>1.8</java-version>

--- a/terasoluna-tourreservation-domain/pom.xml
+++ b/terasoluna-tourreservation-domain/pom.xml
@@ -111,14 +111,6 @@
           <groupId>javax.annotation</groupId>
           <artifactId>javax.annotation-api</artifactId>
         </dependency>
-        <dependency>
-          <groupId>com.sun.xml.bind</groupId>
-          <artifactId>jaxb-core</artifactId>
-        </dependency>
-        <dependency>
-          <groupId>com.sun.xml.bind</groupId>
-          <artifactId>jaxb-impl</artifactId>
-        </dependency>
       </dependencies>
     </profile>
   </profiles>


### PR DESCRIPTION
(cherry picked from commit 8c5fcf87fd42aba27234c4ae574ebd0d7a248c44)

Please review terasolunaorg/terasoluna-tourreservation#673 .

This PR is sideport for MyBatis3 .