### PR TITLE
 Added a setting to output logs during destroy #700

### DIFF
--- a/terasoluna-tourreservation-web/src/main/webapp/WEB-INF/web.xml
+++ b/terasoluna-tourreservation-web/src/main/webapp/WEB-INF/web.xml
@@ -3,7 +3,16 @@
   xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
   version="3.0">
 
+  <context-param>
+    <param-name>logbackDisableServletContainerInitializer</param-name>
+    <param-value>true</param-value>
+  </context-param>
+
   <!-- Listeners -->
+  <listener>
+    <listener-class>ch.qos.logback.classic.servlet.LogbackServletContextListener</listener-class>
+  </listener>
+
   <listener>
     <listener-class>org.springframework.web.context.ContextLoaderListener</listener-class>
   </listener>


### PR DESCRIPTION
(cherry picked from commit 442c97bdf6c8c60379f2855027e2cb6b5dc9bdbb)

Please review https://github.com/terasolunaorg/terasoluna-tourreservation/issues/700.

Confirmation

Confirmed that the addition of the setting causes the output of the log on destroy, which was not output before the modification.
