### PR TITLE
[5.6.x]Remove unnecessary settings from gitignore #706

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,6 @@ target
 .project
 .springBeans
 *~
-.git
 .idea
 .DS_Store
 log


### PR DESCRIPTION
(cherry picked from commit 929a84afe203ab58d180b1176bdca431cb2334ac)
(cherry picked from commit 94e0d8b3b82b680f1fa6d5178a43dfcf7c480a42)

Please review https://github.com/terasolunaorg/terasoluna-tourreservation/issues/708

Removed unnecessary settings from gitignore.