### PR TITLE
[5.7.x] update the plugin version #686

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-war-plugin</artifactId>
-          <version>${maven-war-plugin.version}</version>
+          <version>${org.apache.maven.plugins.maven-war-plugin.version}</version>
           <configuration>
             <warName>${project.artifactId}</warName>
             <archive>
@@ -68,7 +68,7 @@
         <plugin>
           <groupId>net.revelc.code.formatter</groupId>
           <artifactId>formatter-maven-plugin</artifactId>
-          <version>${formatter-maven-plugin.version}</version>
+          <version>${net.revelc.code.formatter.formatter-maven-plugin.version}</version>
           <configuration>
             <configFile>${project.root.basedir}/eclipse/formatter.xml
             </configFile>
@@ -85,7 +85,7 @@
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>xml-maven-plugin</artifactId>
-          <version>${xml-maven-plugin.version}</version>
+          <version>${org.codehaus.mojo.xml-maven-plugin.version}</version>
           <configuration>
             <indentSize>2</indentSize>
           </configuration>
@@ -93,7 +93,7 @@
         <plugin>
           <groupId>com.mycila</groupId>
           <artifactId>license-maven-plugin</artifactId>
-          <version>${license-maven-plugin.version}</version>
+          <version>${com.mycila.license-maven-plugin.version}</version>
           <configuration>
             <header>${project.root.basedir}/license/header.txt</header>
             <includes>
@@ -154,10 +154,10 @@
   </dependencyManagement>
   <properties>
     <!-- == Maven Plugin Versions == -->
-    <maven-war-plugin.version>3.3.1</maven-war-plugin.version>
-    <formatter-maven-plugin.version>2.0.1</formatter-maven-plugin.version>
-    <xml-maven-plugin.version>1.0.2</xml-maven-plugin.version>
-    <license-maven-plugin.version>4.1</license-maven-plugin.version>
+    <org.apache.maven.plugins.maven-war-plugin.version>3.3.1</org.apache.maven.plugins.maven-war-plugin.version>
+    <net.revelc.code.formatter.formatter-maven-plugin.version>2.15.0</net.revelc.code.formatter.formatter-maven-plugin.version>
+    <org.codehaus.mojo.xml-maven-plugin.version>1.0.2</org.codehaus.mojo.xml-maven-plugin.version>
+    <com.mycila.license-maven-plugin.version>4.1</com.mycila.license-maven-plugin.version>
     <!-- == Dependency Versions == -->
     <postgresql.version>42.2.9</postgresql.version>
     <webdrivermanager.version>3.1.1</webdrivermanager.version>

--- a/pom.xml
+++ b/pom.xml
@@ -52,39 +52,6 @@
     <pluginManagement>
       <plugins>
         <plugin>
-          <groupId>org.codehaus.mojo</groupId>
-          <artifactId>build-helper-maven-plugin</artifactId>
-          <version>${org.codehaus.mojo.build-helper-maven-plugi.version}</version>
-          <executions>
-            <execution>
-              <id>add-source</id>
-              <phase>generate-sources</phase>
-              <goals>
-                <goal>add-source</goal>
-              </goals>
-              <configuration>
-                <sources>
-                  <source>src/generated/java</source>
-                </sources>
-              </configuration>
-            </execution>
-            <execution>
-              <id>add-resource</id>
-              <phase>generate-resources</phase>
-              <goals>
-                <goal>add-resource</goal>
-              </goals>
-              <configuration>
-                <resources>
-                  <resource>
-                    <directory>src/generated/resources</directory>
-                  </resource>
-                </resources>
-              </configuration>
-            </execution>
-          </executions>
-        </plugin>
-        <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-war-plugin</artifactId>
           <version>${maven-war-plugin.version}</version>
@@ -124,9 +91,9 @@
           </configuration>
         </plugin>
         <plugin>
-          <groupId>com.google.code.maven-license-plugin</groupId>
-          <artifactId>maven-license-plugin</artifactId>
-          <version>${com.google.code.maven-license-plugin.version}</version>
+          <groupId>com.mycila</groupId>
+          <artifactId>license-maven-plugin</artifactId>
+          <version>${license-maven-plugin.version}</version>
           <configuration>
             <header>${project.root.basedir}/license/header.txt</header>
             <includes>
@@ -187,11 +154,10 @@
   </dependencyManagement>
   <properties>
     <!-- == Maven Plugin Versions == -->
-    <org.codehaus.mojo.build-helper-maven-plugi.version>1.9.1</org.codehaus.mojo.build-helper-maven-plugi.version>
-    <maven-war-plugin.version>2.5</maven-war-plugin.version>
+    <maven-war-plugin.version>3.3.1</maven-war-plugin.version>
     <formatter-maven-plugin.version>2.0.1</formatter-maven-plugin.version>
-    <xml-maven-plugin.version>1.0.1</xml-maven-plugin.version>
-    <com.google.code.maven-license-plugin.version>1.4.0</com.google.code.maven-license-plugin.version>
+    <xml-maven-plugin.version>1.0.2</xml-maven-plugin.version>
+    <license-maven-plugin.version>4.1</license-maven-plugin.version>
     <!-- == Dependency Versions == -->
     <postgresql.version>42.2.9</postgresql.version>
     <webdrivermanager.version>3.1.1</webdrivermanager.version>

--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,56 @@
       <plugins>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-failsafe-plugin</artifactId>
+          <version>${org.apache.maven.plugins.maven-failsafe-plugin.version}</version>
+          <executions>
+            <execution>
+              <goals>
+                <goal>integration-test</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <version>${org.apache.maven.plugins.maven-surefire-plugin.version}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>build-helper-maven-plugin</artifactId>
+          <version>${org.codehaus.mojo.build-helper-maven-plugin.version}</version>
+          <executions>
+            <execution>
+              <id>add-source</id>
+              <phase>generate-sources</phase>
+              <goals>
+                <goal>add-source</goal>
+              </goals>
+              <configuration>
+                <sources>
+                  <source>src/generated/java</source>
+                </sources>
+              </configuration>
+            </execution>
+            <execution>
+              <id>add-resource</id>
+              <phase>generate-resources</phase>
+              <goals>
+                <goal>add-resource</goal>
+              </goals>
+              <configuration>
+                <resources>
+                  <resource>
+                    <directory>src/generated/resources</directory>
+                  </resource>
+                </resources>
+              </configuration>
+            </execution>
+          </executions>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-war-plugin</artifactId>
           <version>${org.apache.maven.plugins.maven-war-plugin.version}</version>
           <configuration>
@@ -155,6 +205,9 @@
   <properties>
     <!-- == Maven Plugin Versions == -->
     <org.apache.maven.plugins.maven-war-plugin.version>3.3.1</org.apache.maven.plugins.maven-war-plugin.version>
+    <org.codehaus.mojo.build-helper-maven-plugin.version>3.2.0</org.codehaus.mojo.build-helper-maven-plugin.version>
+    <org.apache.maven.plugins.maven-failsafe-plugin.version>3.0.0-M5</org.apache.maven.plugins.maven-failsafe-plugin.version>
+    <org.apache.maven.plugins.maven-surefire-plugin.version>3.0.0-M5</org.apache.maven.plugins.maven-surefire-plugin.version>
     <net.revelc.code.formatter.formatter-maven-plugin.version>2.15.0</net.revelc.code.formatter.formatter-maven-plugin.version>
     <org.codehaus.mojo.xml-maven-plugin.version>1.0.2</org.codehaus.mojo.xml-maven-plugin.version>
     <com.mycila.license-maven-plugin.version>4.1</com.mycila.license-maven-plugin.version>

--- a/terasoluna-tourreservation-domain/pom.xml
+++ b/terasoluna-tourreservation-domain/pom.xml
@@ -15,6 +15,15 @@
     <relativePath>../pom.xml</relativePath>
   </parent>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+
   <dependencies>
     <!-- == Begin TERASOLUNA == -->
     <dependency>

--- a/terasoluna-tourreservation-env/pom.xml
+++ b/terasoluna-tourreservation-env/pom.xml
@@ -59,8 +59,8 @@
         </configuration>
       </plugin>
       <plugin>
-        <groupId>com.google.code.maven-license-plugin</groupId>
-        <artifactId>maven-license-plugin</artifactId>
+        <groupId>com.mycila</groupId>
+        <artifactId>license-maven-plugin</artifactId>
       </plugin>
     </plugins>
   </build>

--- a/terasoluna-tourreservation-selenium/pom.xml
+++ b/terasoluna-tourreservation-selenium/pom.xml
@@ -15,6 +15,28 @@
     <relativePath>../pom.xml</relativePath>
   </parent>
 
+    <build>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-failsafe-plugin</artifactId>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <configuration>
+            <excludes>
+              <exclude>**/*IT.java</exclude>
+            </excludes>
+          </configuration>
+        </plugin>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>build-helper-maven-plugin</artifactId>
+        </plugin>
+      </plugins>
+    </build>
+
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/terasoluna-tourreservation-web/pom.xml
+++ b/terasoluna-tourreservation-web/pom.xml
@@ -14,6 +14,23 @@
     <relativePath>../pom.xml</relativePath>
   </parent>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+    <resources>
+      <resource>
+        <directory>${project.basedir}/src/main/resources</directory>
+        <excludes>
+          <exclude>**/reservationReportExcel.xlsx</exclude>
+        </excludes>
+      </resource>
+    </resources>
+  </build>
+
   <!-- Please generate the war file using following Maven command. * Generate for local development environment 
     mvn clean package * Generate for test or production environment (exclude the projectName-env.jar) mvn 
     -P warpack clean package * Generate for test or production environment (include the projectName-env.jar) 
@@ -45,17 +62,6 @@
       </dependencies>
     </profile>
   </profiles>
-
-  <build>
-    <resources>
-      <resource>
-        <directory>${project.basedir}/src/main/resources</directory>
-        <excludes>
-          <exclude>**/reservationReportExcel.xlsx</exclude>
-        </excludes>
-      </resource>
-    </resources>
-  </build>
 
   <dependencies>
     <dependency>


### PR DESCRIPTION
Please review https://github.com/terasolunaorg/terasoluna-tourreservation/issues/715

The changes other than the version upgrade are as follows:

- The `com.google.code:maven-license-plugin` has been changed to `com.mycila:license-maven-plugin` as in https://github.com/terasolunaorg/terasoluna-gfw/issues/600.
- The `build-helper-maven-plugin` didn't seem to be used so I removed it.
- Fixed the variable name of the plugin version to be `groupId.artifactId.pugin.version`.
https://github.com/terasolunaorg/terasoluna-tourreservation-mybatis3/commit/fa8ffb2c4f074840b3a86cb2e09fad643f46b55d