### PR TITLE
check license header in travis #719

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,7 @@ script:
   - mvn -B xml:check-format -f terasoluna-tourreservation-initdb/pom.xml
   - mvn -B xml:check-format -f terasoluna-tourreservation-selenium/pom.xml
   - mvn -B formatter:validate
+  - mvn -B license:check
   - mvn -B -U sql:execute -f terasoluna-tourreservation-initdb/pom.xml -Ddb.url=jdbc:postgresql://127.0.0.1:${PGPORT}/tourreserve -Ddb.password=
   - sed -i -e "s/localhost/localhost:${PGPORT}/" *env/src/main/resources/META-INF/*/*infra.properties
   - mvn -B -U install


### PR DESCRIPTION
(cherry picked from commit ce9562b10310e6029cb1039c0d714ff64c91723d)

Please review https://github.com/terasolunaorg/terasoluna-tourreservation/issues/719

Added a command to check license headers in .travis.yml, similar to the comments below.
https://github.com/terasolunaorg/terasoluna-gfw/pull/1090#issuecomment-897361409
