### PR TITLE
Backport: The display positions of 'companyName' and 'paymentCompanyname' are opposite. 

### DIFF
--- a/terasoluna-tourreservation-web/src/main/webapp/WEB-INF/views/managereservation/updateConfirm.jsp
+++ b/terasoluna-tourreservation-web/src/main/webapp/WEB-INF/views/managereservation/updateConfirm.jsp
@@ -107,7 +107,7 @@
     </tr>
     <tr>
       <td><spring:message code="label.tr.common.paymentAccount" /></td>
-      <td colspan="3"><spring:message code="label.tr.common.companyName" /> <br /> <spring:message
+      <td colspan="3"><spring:message code="label.tr.common.paymentCompanyname" /> <br /> <spring:message
           code="label.tr.common.savingsAccount" /></td>
     </tr>
     <tr>
@@ -117,7 +117,7 @@
     </tr>
     <tr>
       <td><spring:message code="label.tr.common.paymentInquiry" /></td>
-      <td colspan="3"><spring:message code="label.tr.common.paymentCompanyname" /> <spring:message
+      <td colspan="3"><spring:message code="label.tr.common.companyName" /> <spring:message
           code="label.tr.common.companyTel" /> <spring:message code="label.tr.common.companyEmail" />
       </td>
     </tr>


### PR DESCRIPTION
Please review issues terasolunaorg/terasoluna-tourreservation#761

Backport operation log:
    `git cherry-pick -x 507b076c99fa3213859be7d3df33f8da0b9e51c8`